### PR TITLE
Fix uploading of release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,9 +39,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: dist
+          pattern: "!(*Notifications*)"
           merge-multiple: true
       - name: Upload release assets
         id: upload-assets
         uses: softprops/action-gh-release@v2
         with:
-          files: "!(*Notifications*)"
+          files: dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,14 @@ on:
   release:
     types: [published]
 
+  workflow_dispatch:
+    inputs:
+      pypi:
+        description: 'Publish to PyPI'
+        required: true
+        default: false
+        type: boolean
+
 jobs:
   build:
     uses: ./.github/workflows/build.yml
@@ -13,6 +21,7 @@ jobs:
     name: Publish on PyPI
     needs: build
     runs-on: ubuntu-22.04
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.pypi }}
     environment:
       name: pypi
       url: https://pypi.org/p/drive-backup


### PR DESCRIPTION
The regex that `softprops/action-gh-release` uses doesn't support negation but `actions/download-artifact` does. So lets try to only download what artifacts are needed that way we can upload everything.