### PR TITLE
Ignore the c++ files for linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+"src/drive_backup/core/notifications/windows/Drive Backup Notifications/Drive Backup Notifications/wintoastlib.h" linguist-detectable=false
+"src/drive_backup/core/notifications/windows/Drive Backup Notifications/Drive Backup Notifications/wintoastlib.cpp" linguist-detectable=false


### PR DESCRIPTION
On GitHub it is showing that the project is a C++ project because it thinks most of the code is C++. I'm not sure how that much C++ is in the files responsible, but either way this should be solved easily enough with these changes.