### PR TITLE
Add tag_name input to action-gh-release input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,3 +58,4 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: dist/*
+          tag_name: ${{ inputs.tag_name }}


### PR DESCRIPTION
This was a mistake...not sure how I forgot to add this in the last PR.